### PR TITLE
Improve trip planner naming and calendar UX

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@
 // ---------------------------------------------------------------
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import type { FormEvent, JSX } from "react";
 import Globe from "react-globe.gl";
 import * as topojson from "topojson-client";
 import * as THREE from "three";
@@ -28,7 +29,30 @@ type VisitsMap = Record<string, { alpha2?: string; name?: string; dates: string[
 
 type Anchor = { id: string | number; name: string; lat: number; lng: number; area: number };
 
-type Plan = { id: string | number; alpha2?: string; name: string; dateISO: string; endISO?: string };
+type Plan = {
+  id: string | number;
+  alpha2?: string;
+  name: string;
+  startISO: string;
+  endISO?: string;
+  tripName?: string;
+  coverUrl?: string;
+  /** @deprecated kept for older localStorage payloads */
+  dateISO?: string;
+};
+
+type TripActivityCategory = "experience" | "meal" | "travel" | "free" | string;
+
+type TripActivity = {
+  id: string;
+  title: string;
+  startISO: string;
+  endISO: string;
+  category?: TripActivityCategory;
+  notes?: string;
+};
+
+type TripSchedules = Record<string, Record<string, TripActivity[]>>;
 
 type Screen = "map" | "trips" | "reservations" | "settings";
 
@@ -56,6 +80,7 @@ const LS_VISITS = "visited-country-ids";
 const LS_VISITS_META = "visit-dates-by-country";
 const LS_PLANS = "planned-trips";
 const LS_RESERVATIONS = "reservations";
+const LS_TRIP_SCHEDULES = "trip-schedules";
 
 /* ---------- Zoom/label behaviour ---------- */
 const ALT_MIN = 0.7;
@@ -68,6 +93,15 @@ const CONT_OFF = 2.05;
 /* ---------- Textures / styles ---------- */
 const GLOBE_TEXTURE_EARTH =
   "https://unpkg.com/three-globe/example/img/earth-blue-marble.jpg";
+
+const DEFAULT_TRIP_COVERS = [
+  "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1600&q=80",
+  "https://images.unsplash.com/photo-1505761671935-60b3a7427bad?auto=format&fit=crop&w=1600&q=80",
+  "https://images.unsplash.com/photo-1526778548025-fa2f459cd5c1?auto=format&fit=crop&w=1600&q=80",
+  "https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?auto=format&fit=crop&w=1600&q=80",
+  "https://images.unsplash.com/photo-1467269204594-9661b134dd2b?auto=format&fit=crop&w=1600&q=80",
+  "https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1600&q=80",
+];
 
 /* ---------- Helpers ---------- */
 const pad3 = (n: string | number) => String(n).padStart(3, "0");
@@ -133,6 +167,21 @@ function groupDatesByYear(dates: string[]): Record<string, string[]> {
   return out;
 }
 
+function placeholderCover(seed: string | number | undefined) {
+  const source = String(seed ?? "placeholder");
+  if (!DEFAULT_TRIP_COVERS.length) return "";
+  let hash = 0;
+  for (let i = 0; i < source.length; i += 1) {
+    hash = (hash * 31 + source.charCodeAt(i)) >>> 0;
+  }
+  const index = Math.abs(hash) % DEFAULT_TRIP_COVERS.length;
+  return DEFAULT_TRIP_COVERS[index];
+}
+
+function defaultTripCoverFor(plan: Plan) {
+  return placeholderCover(plan.alpha2 || plan.id || plan.name);
+}
+
 function toRad(d: number) {
   return (d * Math.PI) / 180;
 }
@@ -147,11 +196,73 @@ function angDist(a: { lat: number; lng: number }, b: { lat: number; lng: number 
   return deg;
 }
 
-function daysUntil(dateISO: string) {
-  const today = new Date();
-  const target = new Date(dateISO);
-  const ms = target.setHours(0, 0, 0, 0) - today.setHours(0, 0, 0, 0);
-  return Math.ceil(ms / (1000 * 60 * 60 * 24));
+const MINUTES_IN_DAY = 24 * 60;
+
+function normalizeHHMM(value: string, fallback = "09:00") {
+  if (!value) return fallback;
+  const trimmed = value.trim();
+  if (!trimmed) return fallback;
+  if (/^\d{1,2}$/.test(trimmed)) {
+    return `${trimmed.padStart(2, "0")}:00`;
+  }
+  if (/^\d{1,2}:\d{1,2}$/.test(trimmed)) {
+    const [hStr, mStr] = trimmed.split(":");
+    const h = Math.max(0, Math.min(23, parseInt(hStr, 10) || 0));
+    const m = Math.max(0, Math.min(59, parseInt(mStr, 10) || 0));
+    return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+  }
+  return fallback;
+}
+
+function timeToMinutes(value: string) {
+  const [hStr = "0", mStr = "0"] = value.split(":");
+  const h = parseInt(hStr, 10);
+  const m = parseInt(mStr, 10);
+  if (Number.isNaN(h) || Number.isNaN(m)) return 0;
+  return Math.max(0, Math.min(MINUTES_IN_DAY, h * 60 + m));
+}
+
+function minutesToHHMM(min: number) {
+  const clamped = Math.max(0, Math.min(min, MINUTES_IN_DAY - 1));
+  const h = Math.floor(clamped / 60);
+  const m = clamped % 60;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+}
+
+function ensureEndAfterStart(start: string, end: string) {
+  const startMin = timeToMinutes(start);
+  let endMin = timeToMinutes(end);
+  if (endMin <= startMin) {
+    endMin = Math.min(MINUTES_IN_DAY - 1, startMin + 60);
+  }
+  return { start, end: minutesToHHMM(endMin) };
+}
+
+function clipRangeToDay(
+  dateISO: string,
+  startISO: string,
+  endISO?: string
+): { startMin: number; endMin: number } | null {
+  const dayStart = new Date(`${dateISO}T00:00:00`);
+  const dayEnd = new Date(`${dateISO}T23:59:59`);
+  const start = new Date(startISO);
+  const end = endISO ? new Date(endISO) : new Date(start.getTime() + 60 * 60000);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return null;
+  const startMs = Math.max(dayStart.getTime(), start.getTime());
+  const endMs = Math.min(dayEnd.getTime(), Math.max(startMs + 30 * 60000, end.getTime()));
+  if (endMs < dayStart.getTime() || startMs > dayEnd.getTime()) return null;
+  const startMin = Math.max(
+    0,
+    Math.floor((startMs - dayStart.getTime()) / 60000)
+  );
+  const endMin = Math.max(
+    startMin + 30,
+    Math.ceil((endMs - dayStart.getTime()) / 60000)
+  );
+  return {
+    startMin,
+    endMin: Math.min(MINUTES_IN_DAY, endMin),
+  };
 }
 
 /* ---------- Continent anchors ---------- */
@@ -332,9 +443,58 @@ function AppInner() {
   const [plans, setPlans] = useState<Plan[]>(() => {
     if (typeof window === "undefined") return [];
     try {
-      return JSON.parse(window.localStorage.getItem(LS_PLANS) || "[]");
+      const raw = JSON.parse(window.localStorage.getItem(LS_PLANS) || "[]");
+      if (!Array.isArray(raw)) return [];
+      return raw
+        .map((p: any) => {
+          const id = p?.id;
+          const startISO = p?.startISO || p?.dateISO || p?.date || "";
+          const endISO = p?.endISO || p?.finishISO || undefined;
+          const tripName =
+            typeof p?.tripName === "string" && p.tripName.trim()
+              ? p.tripName.trim()
+              : undefined;
+          const countryName =
+            typeof p?.name === "string" && p.name.trim()
+              ? p.name.trim()
+              : typeof p?.country?.name === "string"
+              ? p.country.name
+              : "";
+          const coverUrl =
+            typeof p?.coverUrl === "string" && p.coverUrl.trim()
+              ? p.coverUrl.trim()
+              : undefined;
+          const alpha2 =
+            typeof p?.alpha2 === "string" && p.alpha2.trim()
+              ? p.alpha2.trim()
+              : typeof p?.country?.alpha2 === "string"
+              ? p.country.alpha2
+              : undefined;
+          return {
+            id,
+            alpha2,
+            name: countryName,
+            startISO,
+            endISO,
+            tripName,
+            coverUrl,
+          } as Plan;
+        })
+        .filter((p) => Boolean(p?.id) && Boolean(p.startISO));
     } catch {
       return [];
+    }
+  });
+
+  const [tripSchedules, setTripSchedules] = useState<TripSchedules>(() => {
+    if (typeof window === "undefined") return {};
+    try {
+      const raw = JSON.parse(
+        window.localStorage.getItem(LS_TRIP_SCHEDULES) || "{}"
+      );
+      return raw && typeof raw === "object" ? raw : {};
+    } catch {
+      return {};
     }
   });
 
@@ -367,6 +527,14 @@ function AppInner() {
       window.localStorage.setItem(LS_RESERVATIONS, JSON.stringify(reservations));
   }, [reservations]);
 
+  useEffect(() => {
+    if (typeof window !== "undefined")
+      window.localStorage.setItem(
+        LS_TRIP_SCHEDULES,
+        JSON.stringify(tripSchedules)
+      );
+  }, [tripSchedules]);
+
   const visitedCount = useMemo(() => Object.keys(visits).length, [visits]);
 
   const visitedList = useMemo(() => {
@@ -380,8 +548,6 @@ function AppInner() {
   }, [visits]);
 
   const totalCountries = countries.length;
-  const pctVisited = totalCountries ? (visitedCount / totalCountries) * 100 : 0;
-
   /* Global map state (Settings) */
   const [showCountryNameLabels, setShowCountryNameLabels] = useState(true);
   const [showContinentNameLabels, setShowContinentNameLabels] = useState(true);
@@ -424,28 +590,170 @@ function AppInner() {
     return v ? v.dates.length : 0;
   }
 
-  function addPlanFromPick(countryId: string | number, dateISO: string, endISO?: string) {
+  function addPlanFromPick(
+    countryId: string | number,
+    startISO: string,
+    endISO?: string,
+    tripName?: string
+  ) {
     const info = idInfo.get(countryId) || {};
     const name = info.name || "Unknown";
     const alpha2 = info.alpha2;
-    if (!dateISO) return;
+    if (!startISO) return;
     setPlans((prev) => {
       const exists = prev.find(
-        (p) => String(p.id) === String(countryId) && p.dateISO === dateISO
+        (p) => String(p.id) === String(countryId) && p.startISO === startISO
       );
       if (exists) return prev;
+      const trimmedName = tripName?.trim();
       return [
         ...prev,
-        { id: countryId, alpha2, name, dateISO, endISO },
+        {
+          id: countryId,
+          alpha2,
+          name,
+          startISO,
+          endISO,
+          tripName: trimmedName || undefined,
+        },
       ].sort(
         (a, b) =>
-          new Date(a.dateISO).getTime() - new Date(b.dateISO).getTime()
+          new Date(a.startISO).getTime() - new Date(b.startISO).getTime()
       );
     });
   }
 
   function removePlan(idx: number) {
-    setPlans((prev) => prev.filter((_, i) => i !== idx));
+    setPlans((prev) => {
+      const plan = prev[idx];
+      if (plan) {
+        setTripSchedules((prevSchedules) => {
+          const key = String(plan.id);
+          if (!(key in prevSchedules)) return prevSchedules;
+          const next = { ...prevSchedules };
+          delete next[key];
+          return next;
+        });
+      }
+      return prev.filter((_, i) => i !== idx);
+    });
+  }
+
+  function sortActivities(items: TripActivity[]) {
+    return items.slice().sort((a, b) => a.startISO.localeCompare(b.startISO));
+  }
+
+  function addTripActivity(
+    planId: string | number,
+    dateISO: string,
+    input: { title: string; start: string; end: string; category?: string; notes?: string }
+  ) {
+    const title = input.title?.trim();
+    if (!title || !input.start || !input.end) return;
+    const planKey = String(planId);
+    const normalizedStart = normalizeHHMM(input.start);
+    const normalizedEnd = normalizeHHMM(input.end, normalizedStart);
+    const { end } = ensureEndAfterStart(normalizedStart, normalizedEnd);
+    const startISO = `${dateISO}T${normalizedStart}:00`;
+    const endISO = `${dateISO}T${end}:00`;
+    const item: TripActivity = {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      title,
+      startISO,
+      endISO,
+      category: input.category || undefined,
+      notes: input.notes || undefined,
+    };
+    setTripSchedules((prev) => {
+      const dayMap = { ...(prev[planKey] || {}) };
+      const dayItems = sortActivities([...(dayMap[dateISO] || []), item]);
+      return {
+        ...prev,
+        [planKey]: {
+          ...dayMap,
+          [dateISO]: dayItems,
+        },
+      };
+    });
+  }
+
+  function updateTripActivity(
+    planId: string | number,
+    dateISO: string,
+    activityId: string,
+    updates: { title?: string; start?: string; end?: string; category?: string; notes?: string }
+  ) {
+    const planKey = String(planId);
+    setTripSchedules((prev) => {
+      const dayMap = { ...(prev[planKey] || {}) };
+      const items = (dayMap[dateISO] || []).slice();
+      const idx = items.findIndex((it) => it.id === activityId);
+      if (idx === -1) return prev;
+      const existing = items[idx];
+      const existingStartHHMM = existing.startISO.slice(11, 16) || "09:00";
+      const existingEndHHMM = existing.endISO
+        ? existing.endISO.slice(11, 16)
+        : minutesToHHMM(timeToMinutes(existingStartHHMM) + 60);
+      const nextStartHHMM = updates.start
+        ? normalizeHHMM(updates.start, existingStartHHMM)
+        : existingStartHHMM;
+      const nextEndHHMM = updates.end
+        ? normalizeHHMM(updates.end, existingEndHHMM)
+        : existingEndHHMM;
+      const ensured = ensureEndAfterStart(nextStartHHMM, nextEndHHMM);
+      const nextStart = `${dateISO}T${nextStartHHMM}:00`;
+      const nextEnd = `${dateISO}T${ensured.end}:00`;
+      const nextTitle =
+        "title" in updates
+          ? updates.title?.trim() || existing.title
+          : existing.title;
+      const nextCategory =
+        "category" in updates
+          ? updates.category || undefined
+          : existing.category;
+      const nextNotes =
+        "notes" in updates
+          ? updates.notes?.trim() || undefined
+          : existing.notes;
+      items[idx] = {
+        ...existing,
+        title: nextTitle,
+        category: nextCategory,
+        notes: nextNotes,
+        startISO: nextStart,
+        endISO: nextEnd,
+      };
+      dayMap[dateISO] = sortActivities(items);
+      return {
+        ...prev,
+        [planKey]: dayMap,
+      };
+    });
+  }
+
+  function removeTripActivity(
+    planId: string | number,
+    dateISO: string,
+    activityId: string
+  ) {
+    const planKey = String(planId);
+    setTripSchedules((prev) => {
+      const dayMap = { ...(prev[planKey] || {}) };
+      const items = (dayMap[dateISO] || []).filter((it) => it.id !== activityId);
+      if (!items.length) {
+        if (!dayMap[dateISO]) return prev;
+        delete dayMap[dateISO];
+      } else {
+        dayMap[dateISO] = items;
+      }
+      const next = { ...prev };
+      if (Object.keys(dayMap).length === 0) {
+        delete next[planKey];
+      } else {
+        next[planKey] = dayMap;
+      }
+      return next;
+    });
   }
 
   return (
@@ -460,7 +768,6 @@ function AppInner() {
           visitedList={visitedList}
           visitedCount={visitedCount}
           totalCountries={totalCountries}
-          pctVisited={pctVisited}
           onAddVisit={addVisitById}
           getVisitCount={visitCountFor}
           mapStyle={mapStyle}
@@ -474,8 +781,14 @@ function AppInner() {
           plans={plans}
           allCountries={allCountries}
           reservations={reservations}
-          onAdd={(id, dateISO, endISO) => addPlanFromPick(id, dateISO, endISO)}
+          schedules={tripSchedules}
+          onAdd={(id, startISO, endISO, tripName) =>
+            addPlanFromPick(id, startISO, endISO, tripName)
+          }
           onRemove={removePlan}
+          onAddActivity={addTripActivity}
+          onUpdateActivity={updateTripActivity}
+          onRemoveActivity={removeTripActivity}
         />
       )}
       {screen === "reservations" && (
@@ -514,7 +827,6 @@ function MapScreen(props: {
   visitedList: { id: string | number; name: string; alpha2?: string; dates: string[] }[];
   visitedCount: number;
   totalCountries: number;
-  pctVisited: number;
   onAddVisit: (id: string | number) => void;
   getVisitCount: (id: string | number) => number;
   mapStyle: MapStyle;
@@ -531,7 +843,6 @@ function MapScreen(props: {
     visitedList,
     visitedCount,
     totalCountries,
-    pctVisited,
     onAddVisit,
     getVisitCount,
     mapStyle,
@@ -574,6 +885,11 @@ function MapScreen(props: {
     if (!found || !globeRef.current) return;
     globeRef.current.pointOfView({ lat: found.lat, lng: found.lng, altitude: 1.1 }, 1000);
     setHomeQuery("");
+    setControlsDisabled(false);
+    if (typeof document !== "undefined") {
+      const active = document.activeElement as HTMLElement | null;
+      active?.blur?.();
+    }
   }
 
   function countryLabelCapForAltitude(a: number) {
@@ -660,8 +976,11 @@ function MapScreen(props: {
     }
     if (showCountriesOverlay && typeof window !== "undefined")
       window.addEventListener("keydown", onEsc);
-    return () =>
-      typeof window !== "undefined" && window.removeEventListener("keydown", onEsc);
+    return () => {
+      if (typeof window !== "undefined") {
+        window.removeEventListener("keydown", onEsc);
+      }
+    };
   }, [showCountriesOverlay]);
 
   useEffect(() => {
@@ -765,6 +1084,7 @@ function MapScreen(props: {
               outline: "none",
               background: "rgba(255,255,255,0.95)",
               boxShadow: "0 8px 28px rgba(0,0,0,.12)",
+              fontSize: 16,
             }}
           />
           {homeQuery && topResults.length > 0 && (
@@ -1039,10 +1359,42 @@ function TripsScreen(props: {
   plans: Plan[];
   allCountries: { id: string | number; alpha2?: string; name: string; flag: string }[];
   reservations: Reservation[];
-  onAdd: (id: string | number, dateISO: string, endISO?: string) => void;
+  schedules: TripSchedules;
+  onAdd: (
+    id: string | number,
+    startISO: string,
+    endISO: string | undefined,
+    tripName?: string
+  ) => void;
   onRemove: (index: number) => void;
+  onAddActivity: (
+    planId: string | number,
+    dateISO: string,
+    input: { title: string; start: string; end: string; category?: string; notes?: string }
+  ) => void;
+  onUpdateActivity: (
+    planId: string | number,
+    dateISO: string,
+    activityId: string,
+    updates: { title?: string; start?: string; end?: string; category?: string; notes?: string }
+  ) => void;
+  onRemoveActivity: (
+    planId: string | number,
+    dateISO: string,
+    activityId: string
+  ) => void;
 }): JSX.Element {
-  const { plans, allCountries, reservations, onAdd, onRemove } = props;
+  const {
+    plans,
+    allCountries,
+    reservations,
+    schedules,
+    onAdd,
+    onRemove,
+    onAddActivity,
+    onUpdateActivity,
+    onRemoveActivity,
+  } = props;
   const [planQuery, setPlanQuery] = useState("");
   const [selectedCountry, setSelectedCountry] = useState<{ id: string | number; alpha2?: string; name: string; flag: string } | null>(null);
   const [showDatePicker, setShowDatePicker] = useState(false);
@@ -1050,6 +1402,36 @@ function TripsScreen(props: {
 
   // Cover images saved locally per plan id (so we don't need parent mutator)
   const [coverMap, setCoverMap] = useState<Record<string, string>>({});
+
+  const openTripSchedule = useMemo(() => {
+    if (!openTrip) return {} as Record<string, TripActivity[]>;
+    return schedules[String(openTrip.id)] || {};
+  }, [openTrip, schedules]);
+
+  const openTripReservations = useMemo(() => {
+    if (!openTrip) return [] as Reservation[];
+    const planId = String(openTrip.id);
+    const start = new Date(openTrip.startISO + "T00:00:00");
+    const end = new Date((openTrip.endISO || openTrip.startISO) + "T23:59:59");
+    const startMs = start.getTime();
+    const endMs = end.getTime();
+    return reservations
+      .filter((r) => {
+        if (String((r as any).planId || "") === planId) return true;
+        const resStart = new Date(r.startISO).getTime();
+        const resEnd = r.endISO
+          ? new Date(r.endISO).getTime()
+          : resStart;
+        if (!Number.isFinite(resStart)) return false;
+        return resStart <= endMs && resEnd >= startMs;
+      })
+      .sort((a, b) => a.startISO.localeCompare(b.startISO));
+  }, [reservations, openTrip]);
+
+  const openTripCountry = useMemo(() => {
+    if (!openTrip) return undefined;
+    return allCountries.find((c) => String(c.id) === String(openTrip.id));
+  }, [openTrip, allCountries]);
 
   const suggestions = useMemo(() => {
     const q = planQuery.trim().toLowerCase();
@@ -1090,15 +1472,15 @@ function TripsScreen(props: {
               setShowDatePicker(true);
             }
           }}
-          style={{
-            width: "100%",
-            padding: "12px 14px",
-            borderRadius: 12,
-            border: "1px solid #e5e7eb",
-            outline: "none",
-            fontSize: 15,
-          }}
-        />
+        style={{
+          width: "100%",
+          padding: "12px 14px",
+          borderRadius: 12,
+          border: "1px solid #e5e7eb",
+          outline: "none",
+          fontSize: 16,
+        }}
+      />
         {planQuery.trim() && suggestions.length > 0 && !selectedCountry && (
           <div style={{ position:"absolute", left:0, right:0, top:"calc(100% + 6px)", border:"1px solid #e5e7eb", background:"#fff", borderRadius:12, boxShadow:"0 12px 40px rgba(0,0,0,.18)", zIndex:10, maxHeight:260, overflow:"auto" }}>
             {suggestions.map((c) => (
@@ -1119,34 +1501,170 @@ function TripsScreen(props: {
       {plans.length === 0 ? (
         <div style={{ color:"#64748b" }}>No trips yet. Add one above.</div>
       ) : (
-        <ul style={{ listStyle:"none", margin:0, padding:0, display:"grid", gap:12 }}>
+        <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "grid", gap: 12 }}>
           {plans.map((pl, idx) => {
-            const cover = coverFor(pl.id, (pl as any).coverUrl);
-            const daysLeft = Math.ceil((new Date(pl.startISO).getTime() - Date.now()) / (24*3600*1000));
+            const countryInfo = allCountries.find(
+              (c) => String(c.id) === String(pl.id)
+            );
+            const flag = countryInfo?.flag || flagFromAlpha2(pl.alpha2);
+            const countryName = countryInfo?.name || pl.name || "Destination";
+            const tripTitle =
+              pl.tripName && pl.tripName.trim()
+                ? pl.tripName.trim()
+                : `Trip to ${countryName}`;
+            const cover = coverFor(pl.id, pl.coverUrl);
+            const displayCover = cover || defaultTripCoverFor(pl);
+            const dayDifference = Math.ceil(
+              (new Date(pl.startISO).getTime() - Date.now()) /
+                (24 * 3600 * 1000)
+            );
+            let countdownLabel = "";
+            if (Number.isFinite(dayDifference)) {
+              if (dayDifference > 0) {
+                countdownLabel = `${dayDifference} day${dayDifference === 1 ? "" : "s"} away`;
+              } else if (dayDifference === 0) {
+                countdownLabel = "Starts today";
+              } else {
+                const diff = Math.abs(dayDifference);
+                countdownLabel = `Started ${diff} day${diff === 1 ? "" : "s"} ago`;
+              }
+            }
+            const dateLabel = pl.endISO
+              ? `${pl.startISO} → ${pl.endISO}`
+              : pl.startISO;
+            const handleOpen = () => setOpenTrip(pl);
             return (
               <li key={String(pl.id)}>
-                <div style={{ border:"1px solid #e5e7eb", borderRadius:16, background:"#fff", overflow:"hidden" }}>
-                  <div style={{ position:"relative", height: 140, background: cover ? `center/cover url(${cover})` : "#e2e8f0" }}>
-                    <button
-                      onClick={() => setOpenTrip(pl)}
-                      style={{ position:"absolute", inset:0, border:0, background:"transparent", cursor:"pointer" }}
-                      aria-label="Open trip"
+                <div
+                  role="button"
+                  tabIndex={0}
+                  onClick={handleOpen}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      handleOpen();
+                    }
+                  }}
+                  aria-label={`Open ${tripTitle}`}
+                  style={{
+                    border: "1px solid #e5e7eb",
+                    borderRadius: 18,
+                    background: "#fff",
+                    overflow: "hidden",
+                    cursor: "pointer",
+                    display: "grid",
+                    boxShadow: "0 14px 40px rgba(15,23,42,0.08)",
+                  }}
+                >
+                  <div
+                    style={{
+                      position: "relative",
+                      height: 160,
+                      background: displayCover
+                        ? `center/cover no-repeat url(${displayCover})`
+                        : "linear-gradient(120deg,#0ea5e9,#0369a1)",
+                    }}
+                  >
+                    <div
+                      style={{
+                        position: "absolute",
+                        inset: 0,
+                        background:
+                          "linear-gradient(180deg,rgba(15,23,42,0.1),rgba(15,23,42,0.55))",
+                      }}
                     />
-                  </div>
-                  <div style={{ padding:12, display:"grid", gap:6 }}>
-                    <div style={{ display:"flex", alignItems:"center", gap:8 }}>
-                      <span style={{ fontSize:20 }}>{(pl as any).country?.flag || ""}</span>
-                      <div style={{ fontWeight:800 }}>{(pl as any).country?.name || "Trip"}</div>
-                      <div style={{ marginLeft:"auto", fontSize:12, color:"#64748b" }}>
-                        {isFinite(daysLeft) ? (daysLeft >= 0 ? `${daysLeft} days` : `started`) : ""}
+                    <div
+                      style={{
+                        position: "absolute",
+                        inset: 0,
+                        display: "flex",
+                        flexDirection: "column",
+                        justifyContent: "space-between",
+                        padding: 16,
+                        color: "#fff",
+                      }}
+                    >
+                      <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                        <span style={{ fontSize: 22 }}>{flag}</span>
+                        <span style={{ fontWeight: 700 }}>{countryName}</span>
+                        {countdownLabel && (
+                          <span
+                            style={{
+                              marginLeft: "auto",
+                              background: "rgba(15,23,42,0.35)",
+                              padding: "4px 10px",
+                              borderRadius: 999,
+                              fontSize: 11,
+                              fontWeight: 700,
+                            }}
+                          >
+                            {countdownLabel}
+                          </span>
+                        )}
+                      </div>
+                      <div>
+                        <div style={{ fontSize: 20, fontWeight: 800 }}>
+                          {tripTitle}
+                        </div>
+                        {!cover && (
+                          <div
+                            style={{
+                              marginTop: 6,
+                              display: "inline-flex",
+                              alignItems: "center",
+                              gap: 6,
+                              background: "rgba(255,255,255,0.18)",
+                              padding: "4px 10px",
+                              borderRadius: 999,
+                              fontSize: 11,
+                            }}
+                          >
+                            <span role="img" aria-hidden="true">
+                              📸
+                            </span>
+                            Default cover — add your own photo anytime
+                          </div>
+                        )}
                       </div>
                     </div>
-                    <div style={{ fontSize:12, color:"#475569" }}>
-                      {pl.startISO} {(pl as any).endISO ? `→ ${(pl as any).endISO}` : ""}
+                  </div>
+                  <div style={{ padding: 14, display: "grid", gap: 8 }}>
+                    <div style={{ fontSize: 13, color: "#475569" }}>{dateLabel}</div>
+                    <div
+                      style={{
+                        fontSize: 12,
+                        color: "#64748b",
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 6,
+                      }}
+                    >
+                      <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+                        <span role="img" aria-hidden="true">
+                          🗓️
+                        </span>
+                        Tap anywhere to see the daily planner
+                      </span>
                     </div>
-                    <div style={{ display:"flex", gap:8, marginTop:4 }}>
-                      <button onClick={() => setOpenTrip(pl)} style={{ border:"1px solid #e5e7eb", borderRadius:8, padding:"6px 10px" }}>Open</button>
-                      <button onClick={() => onRemove(idx)} style={{ border:"1px solid #fee2e2", background:"#fef2f2", color:"#991b1b", borderRadius:8, padding:"6px 10px" }}>Remove</button>
+                    <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onRemove(idx);
+                        }}
+                        style={{
+                          border: "1px solid #fee2e2",
+                          background: "#fef2f2",
+                          color: "#b91c1c",
+                          borderRadius: 999,
+                          padding: "6px 14px",
+                          fontSize: 12,
+                          fontWeight: 700,
+                          cursor: "pointer",
+                        }}
+                      >
+                        Remove
+                      </button>
                     </div>
                   </div>
                 </div>
@@ -1161,8 +1679,8 @@ function TripsScreen(props: {
     {showDatePicker && selectedCountry && (
       <TripDatePicker
         country={selectedCountry}
-        onConfirm={(startISO, endISO) => {
-          onAdd(selectedCountry.id, startISO, endISO);
+        onConfirm={(startISO, endISO, tripName) => {
+          onAdd(selectedCountry.id, startISO, endISO, tripName);
           setShowDatePicker(false);
           setSelectedCountry(null);
           setPlanQuery("");
@@ -1175,9 +1693,22 @@ function TripsScreen(props: {
     {openTrip && (
       <TripDetailsOverlay
         plan={openTrip}
-        reservations={reservations.filter(r => String((r as any).planId) === String((openTrip as any).id))}
-        coverUrl={coverFor((openTrip as any).id, (openTrip as any).coverUrl)}
-        onChangeCover={(dataUrl) => setCoverMap(prev => ({ ...prev, [String((openTrip as any).id)]: dataUrl }))}
+        country={openTripCountry}
+        reservations={openTripReservations}
+        activitiesByDay={openTripSchedule}
+        onAddActivity={(dateISO, payload) =>
+          onAddActivity(openTrip.id, dateISO, payload)
+        }
+        onUpdateActivity={(dateISO, activityId, updates) =>
+          onUpdateActivity(openTrip.id, dateISO, activityId, updates)
+        }
+        onRemoveActivity={(dateISO, activityId) =>
+          onRemoveActivity(openTrip.id, dateISO, activityId)
+        }
+        coverUrl={coverFor(openTrip.id, openTrip.coverUrl)}
+        onChangeCover={(dataUrl) =>
+          setCoverMap((prev) => ({ ...prev, [String(openTrip.id)]: dataUrl }))
+        }
         onClose={() => setOpenTrip(null)}
       />
     )}
@@ -1186,29 +1717,114 @@ function TripsScreen(props: {
 
 
 
-function TripDatePicker({ country, onConfirm, onClose }: {
+function TripDatePicker({
+  country,
+  onConfirm,
+  onClose,
+}: {
   country: { id: string | number; alpha2?: string; name: string; flag: string };
-  onConfirm: (startISO: string, endISO?: string) => void;
+  onConfirm: (startISO: string, endISO?: string, tripName?: string) => void;
   onClose: () => void;
 }): JSX.Element {
   const [start, setStart] = useState<string>("");
   const [end, setEnd] = useState<string>("");
+  const [tripName, setTripName] = useState<string>(() =>
+    country.name ? `Trip to ${country.name}` : "My adventure"
+  );
+  const disableAdd = !start;
   return (
-    <div style={{ position:"fixed", inset:0, background:"rgba(0,0,0,.40)", display:"grid", placeItems:"center", zIndex:600 }} onClick={onClose}>
-      <div style={{ width:"min(440px,92vw)", background:"#fff", borderRadius:16, boxShadow:"0 24px 80px rgba(0,0,0,.35)", padding:16 }} onClick={(e) => e.stopPropagation()}>
-        <div style={{ display:"flex", alignItems:"center", gap:8, marginBottom:12 }}>
-          <div style={{ fontSize:24 }}>{country.flag}</div>
-          <div style={{ fontWeight:800, fontSize:16 }}>{country.name}</div>
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,.40)",
+        display: "grid",
+        placeItems: "center",
+        zIndex: 600,
+        padding: 16,
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          width: "min(460px, 92vw)",
+          background: "#fff",
+          borderRadius: 16,
+          boxShadow: "0 24px 80px rgba(0,0,0,.35)",
+          padding: 20,
+          display: "grid",
+          gap: 14,
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <div style={{ fontSize: 28 }}>{country.flag}</div>
+          <div style={{ fontWeight: 800, fontSize: 18 }}>{country.name}</div>
         </div>
-        <div style={{ display:"grid", gap:8 }}>
-          <label style={{ fontSize:12, color:"#475569" }}>Start date</label>
-          <input type="date" value={start} onChange={(e) => setStart(e.target.value)} style={{ padding:"10px 12px", borderRadius:10, border:"1px solid #e5e7eb" }} />
-          <label style={{ fontSize:12, color:"#475569" }}>End date (optional)</label>
-          <input type="date" value={end} onChange={(e) => setEnd(e.target.value)} style={{ padding:"10px 12px", borderRadius:10, border:"1px solid #e5e7eb" }} />
-          <div style={{ display:"flex", justifyContent:"flex-end", gap:8, marginTop:8 }}>
-            <button onClick={onClose} style={{ padding:"8px 12px", borderRadius:10, border:"1px solid #e5e7eb" }}>Cancel</button>
-            <button onClick={() => { if (!start) return; onConfirm(start, end || undefined); }} style={{ padding:"8px 12px", borderRadius:10, border:"1px solid #0ea5a8", backgroundImage:"linear-gradient(90deg,#06b6d4,#0ea5a8)", color:"#fff", fontWeight:800 }}>Add trip</button>
-          </div>
+        <div style={{ display: "grid", gap: 10 }}>
+          <label style={{ fontSize: 12, color: "#475569", fontWeight: 600 }}>
+            Trip name
+          </label>
+          <input
+            type="text"
+            value={tripName}
+            onChange={(e) => setTripName(e.target.value)}
+            placeholder="Name your adventure"
+            style={{
+              padding: "10px 12px",
+              borderRadius: 10,
+              border: "1px solid #e5e7eb",
+              fontSize: 16,
+            }}
+          />
+        </div>
+        <div style={{ display: "grid", gap: 8 }}>
+          <label style={{ fontSize: 12, color: "#475569" }}>Start date</label>
+          <input
+            type="date"
+            value={start}
+            onChange={(e) => setStart(e.target.value)}
+            style={{ padding: "10px 12px", borderRadius: 10, border: "1px solid #e5e7eb", fontSize: 16 }}
+          />
+          <label style={{ fontSize: 12, color: "#475569" }}>End date (optional)</label>
+          <input
+            type="date"
+            value={end}
+            onChange={(e) => setEnd(e.target.value)}
+            style={{ padding: "10px 12px", borderRadius: 10, border: "1px solid #e5e7eb", fontSize: 16 }}
+          />
+        </div>
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+          <button
+            onClick={onClose}
+            style={{
+              padding: "8px 12px",
+              borderRadius: 10,
+              border: "1px solid #e5e7eb",
+              background: "#f8fafc",
+              fontWeight: 600,
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => {
+              if (disableAdd) return;
+              onConfirm(start, end || undefined, tripName.trim());
+            }}
+            style={{
+              padding: "8px 14px",
+              borderRadius: 10,
+              border: "1px solid #0ea5a8",
+              backgroundImage: "linear-gradient(90deg,#06b6d4,#0ea5a8)",
+              color: "#fff",
+              fontWeight: 800,
+              opacity: disableAdd ? 0.6 : 1,
+              cursor: disableAdd ? "not-allowed" : "pointer",
+            }}
+          >
+            Add trip
+          </button>
         </div>
       </div>
     </div>
@@ -1217,115 +1833,1222 @@ function TripDatePicker({ country, onConfirm, onClose }: {
 
 function TripDetailsOverlay({
   plan,
+  country,
   reservations,
+  activitiesByDay,
+  onAddActivity,
+  onUpdateActivity,
+  onRemoveActivity,
   coverUrl,
   onChangeCover,
   onClose,
 }: {
   plan: Plan;
+  country?: { name: string; flag?: string };
   reservations: Reservation[];
+  activitiesByDay: Record<string, TripActivity[]>;
+  onAddActivity: (
+    dateISO: string,
+    input: { title: string; start: string; end: string; category?: string; notes?: string }
+  ) => void;
+  onUpdateActivity: (
+    dateISO: string,
+    activityId: string,
+    updates: { title?: string; start?: string; end?: string; category?: string; notes?: string }
+  ) => void;
+  onRemoveActivity: (dateISO: string, activityId: string) => void;
   coverUrl?: string;
   onChangeCover?: (dataUrl: string) => void;
   onClose: () => void;
 }): JSX.Element {
-  const byDay = useMemo(() => {
-    const map: Record<string, Reservation[]> = {};
-    reservations.forEach(r => {
-      const d = (r.startISO || "").slice(0,10);
-      if (!d) return;
-      (map[d] ||= []).push(r);
-    });
+  const dayList = useMemo(() => {
     const days: string[] = [];
     const start = new Date(plan.startISO + "T00:00:00");
-    const end = new Date(((plan as any).endISO || plan.startISO) + "T00:00:00");
-    for (let t = start.getTime(); t <= end.getTime(); t += 24*3600*1000) {
-      days.push(new Date(t).toISOString().slice(0,10));
+    const end = new Date((plan.endISO || plan.startISO) + "T00:00:00");
+    for (let t = start.getTime(); t <= end.getTime(); t += 24 * 3600 * 1000) {
+      days.push(new Date(t).toISOString().slice(0, 10));
     }
-    return days.map(d => ({ d, items: (map[d] || []).slice().sort((a,b) => a.startISO.localeCompare(b.startISO)) }));
-  }, [reservations, plan.startISO, (plan as any).endISO]);
+    return days;
+  }, [plan.startISO, plan.endISO]);
+
+  const [selectedDay, setSelectedDay] = useState<string>(
+    dayList[0] || plan.startISO
+  );
+
+  useEffect(() => {
+    setSelectedDay((prev) => {
+      if (prev && dayList.includes(prev)) return prev;
+      return dayList[0] || plan.startISO;
+    });
+  }, [dayList, plan.startISO]);
+
+  const tripDaySet = useMemo(() => new Set(dayList), [dayList]);
+
+  const activityCountByDay = useMemo(() => {
+    const map: Record<string, number> = {};
+    dayList.forEach((iso) => {
+      map[iso] = (activitiesByDay[iso] || []).length;
+    });
+    return map;
+  }, [activitiesByDay, dayList]);
+
+  const reservationsByDay = useMemo(() => {
+    const map: Record<string, number> = {};
+    reservations.forEach((r) => {
+      const iso = new Date(r.startISO).toISOString().slice(0, 10);
+      if (!tripDaySet.has(iso)) return;
+      map[iso] = (map[iso] || 0) + 1;
+    });
+    return map;
+  }, [reservations, tripDaySet]);
+
+  const calendarMonths = useMemo(() => {
+    if (!dayList.length)
+      return [] as {
+        key: string;
+        label: string;
+        cells: {
+          iso?: string;
+          label?: number;
+          inTrip: boolean;
+          activityCount: number;
+          reservationCount: number;
+        }[];
+      }[];
+    const first = new Date(dayList[0] + "T00:00:00");
+    const last = new Date(dayList[dayList.length - 1] + "T00:00:00");
+    const months: {
+      key: string;
+      label: string;
+      cells: {
+        iso?: string;
+        label?: number;
+        inTrip: boolean;
+        activityCount: number;
+        reservationCount: number;
+      }[];
+    }[] = [];
+    let iter = new Date(
+      Date.UTC(first.getUTCFullYear(), first.getUTCMonth(), 1)
+    );
+    const endIter = new Date(
+      Date.UTC(last.getUTCFullYear(), last.getUTCMonth(), 1)
+    );
+    while (iter <= endIter) {
+      const year = iter.getUTCFullYear();
+      const month = iter.getUTCMonth();
+      const label = new Date(Date.UTC(year, month, 1)).toLocaleDateString(
+        undefined,
+        {
+          month: "long",
+          year: "numeric",
+        }
+      );
+      const firstWeekday = new Date(Date.UTC(year, month, 1)).getUTCDay();
+      const daysInMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+      const cells: {
+        iso?: string;
+        label?: number;
+        inTrip: boolean;
+        activityCount: number;
+        reservationCount: number;
+      }[] = [];
+      for (let i = 0; i < firstWeekday; i += 1) {
+        cells.push({ inTrip: false, activityCount: 0, reservationCount: 0 });
+      }
+      for (let day = 1; day <= daysInMonth; day += 1) {
+        const iso = new Date(Date.UTC(year, month, day))
+          .toISOString()
+          .slice(0, 10);
+        const inTrip = tripDaySet.has(iso);
+        cells.push({
+          iso,
+          label: day,
+          inTrip,
+          activityCount: activityCountByDay[iso] || 0,
+          reservationCount: reservationsByDay[iso] || 0,
+        });
+      }
+      while (cells.length % 7 !== 0) {
+        cells.push({ inTrip: false, activityCount: 0, reservationCount: 0 });
+      }
+      months.push({
+        key: `${year}-${month}`,
+        label,
+        cells,
+      });
+      iter = new Date(Date.UTC(year, month + 1, 1));
+    }
+    return months;
+  }, [dayList, tripDaySet, activityCountByDay, reservationsByDay]);
+
+  const tripName =
+    plan.tripName?.trim() ||
+    `Trip to ${country?.name || plan.name || "Destination"}`;
+  const flag = country?.flag || flagFromAlpha2(plan.alpha2);
+  const countryLabel = country?.name || plan.name || "";
+  const heroCover =
+    coverUrl && coverUrl.trim() ? coverUrl : defaultTripCoverFor(plan);
+  const coverInputId = `cover-file-${String(plan.id)}`;
+  const totalActivities = Object.values(activityCountByDay).reduce(
+    (sum, count) => sum + count,
+    0
+  );
+  const totalReservations = reservations.length;
+  const tripLength = dayList.length;
+
+  const selectedDate = selectedDay
+    ? new Date(`${selectedDay}T00:00:00`)
+    : null;
+  const selectedDayLabel = selectedDate
+    ? selectedDate.toLocaleDateString(undefined, {
+        weekday: "long",
+        month: "long",
+        day: "numeric",
+      })
+    : "";
+  const selectedActivities = activityCountByDay[selectedDay] || 0;
+  const selectedReservations = reservationsByDay[selectedDay] || 0;
+
+  const WEEK_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
   return (
-    <div style={{ position:"fixed", inset:0, background:"rgba(0,0,0,.45)", display:"grid", placeItems:"center", zIndex:650 }} onClick={onClose}>
-      <div style={{ width:"min(900px,96vw)", background:"#fff", borderRadius:16, boxShadow:"0 24px 80px rgba(0,0,0,.45)", padding:16, maxHeight:"90svh", overflow:"auto" }} onClick={(e) => e.stopPropagation()}>
-        <div style={{ display:"flex", alignItems:"center", justifyContent:"space-between" }}>
-          <div style={{ display:"flex", alignItems:"center", gap:8 }}>
-            <div style={{ fontSize:22 }}>{(plan as any).country?.flag || ""}</div>
-            <div style={{ fontWeight:900 }}>{(plan as any).country?.name || "Trip"}</div>
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0,0,0,.45)",
+        display: "grid",
+        placeItems: "center",
+        zIndex: 650,
+        padding: 16,
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          width: "min(960px, 96vw)",
+          background: "#fff",
+          borderRadius: 20,
+          boxShadow: "0 24px 80px rgba(0,0,0,.45)",
+          padding: 24,
+          maxHeight: "92svh",
+          overflow: "auto",
+          display: "grid",
+          gap: 20,
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            flexWrap: "wrap",
+            gap: 16,
+          }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            {flag && <span style={{ fontSize: 30 }}>{flag}</span>}
+            <div>
+              <div style={{ fontSize: 24, fontWeight: 800, color: "#0f172a" }}>
+                {tripName}
+              </div>
+              {countryLabel && (
+                <div style={{ fontSize: 13, color: "#64748b" }}>{countryLabel}</div>
+              )}
+            </div>
           </div>
-          <div style={{ display:"flex", gap:8 }}>
-            <input id={"cover-file-"+String((plan as any).id)} type="file" accept="image/*" style={{ display:"none" }} onChange={(e) => {
-              const f = (e.target as HTMLInputElement).files?.[0];
-              if (!f || !onChangeCover) return;
-              const r = new FileReader();
-              r.onload = () => onChangeCover(String(r.result));
-              r.readAsDataURL(f);
-            }} />
-            <button onClick={() => { const el = document.getElementById("cover-file-"+String((plan as any).id)) as HTMLInputElement | null; el?.click(); }} style={{ border:"1px solid #e5e7eb", borderRadius:8, padding:"6px 10px" }}>Change cover</button>
-            <button onClick={onClose} style={{ border:"1px solid #e5e7eb", borderRadius:8, padding:"6px 10px" }}>Close</button>
+          <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+            <input
+              id={coverInputId}
+              type="file"
+              accept="image/*"
+              style={{ display: "none" }}
+              onChange={(e) => {
+                const f = (e.target as HTMLInputElement).files?.[0];
+                if (!f || !onChangeCover) return;
+                const reader = new FileReader();
+                reader.onload = () => onChangeCover(String(reader.result));
+                reader.readAsDataURL(f);
+              }}
+            />
+            <button
+              onClick={() => {
+                const el = document.getElementById(
+                  coverInputId
+                ) as HTMLInputElement | null;
+                el?.click();
+              }}
+              style={{
+                border: "1px solid #e5e7eb",
+                borderRadius: 10,
+                padding: "6px 14px",
+                background: "#f8fafc",
+                cursor: "pointer",
+                fontWeight: 600,
+              }}
+            >
+              Change cover
+            </button>
+            <button
+              onClick={onClose}
+              style={{
+                border: "1px solid #e5e7eb",
+                borderRadius: 10,
+                padding: "6px 14px",
+                background: "#fff",
+                cursor: "pointer",
+                fontWeight: 600,
+              }}
+            >
+              Close
+            </button>
           </div>
         </div>
 
-        <div style={{ height:220, marginTop:12, borderRadius:12, background: coverUrl ? `center/cover url(${coverUrl})` : "#e2e8f0" }} />
+        <div
+          style={{
+            position: "relative",
+            height: 240,
+            borderRadius: 18,
+            overflow: "hidden",
+            background: heroCover
+              ? `center/cover no-repeat url(${heroCover})`
+              : "linear-gradient(120deg,#0ea5e9,#0369a1)",
+          }}
+        >
+          <div
+            style={{
+              position: "absolute",
+              inset: 0,
+              background:
+                "linear-gradient(180deg,rgba(15,23,42,0.12),rgba(15,23,42,0.65))",
+            }}
+          />
+          <div
+            style={{
+              position: "absolute",
+              bottom: 18,
+              left: 18,
+              right: 18,
+              display: "flex",
+              flexWrap: "wrap",
+              gap: 10,
+              color: "#fff",
+            }}
+          >
+            <span
+              style={{
+                background: "rgba(15,23,42,0.35)",
+                padding: "6px 14px",
+                borderRadius: 999,
+                fontSize: 12,
+                fontWeight: 700,
+              }}
+            >
+              {tripLength} day{tripLength === 1 ? "" : "s"}
+            </span>
+            <span
+              style={{
+                background: "rgba(14,165,233,0.35)",
+                padding: "6px 14px",
+                borderRadius: 999,
+                fontSize: 12,
+                fontWeight: 700,
+              }}
+            >
+              {totalReservations} reservation{totalReservations === 1 ? "" : "s"}
+            </span>
+            <span
+              style={{
+                background: "rgba(34,197,94,0.35)",
+                padding: "6px 14px",
+                borderRadius: 999,
+                fontSize: 12,
+                fontWeight: 700,
+              }}
+            >
+              {totalActivities} planned item{totalActivities === 1 ? "" : "s"}
+            </span>
+            {!coverUrl && (
+              <span
+                style={{
+                  background: "rgba(255,255,255,0.22)",
+                  padding: "6px 14px",
+                  borderRadius: 999,
+                  fontSize: 12,
+                  fontWeight: 600,
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 8,
+                }}
+              >
+                <span role="img" aria-hidden="true">
+                  📸
+                </span>
+                Default cover — upload a photo to personalise
+              </span>
+            )}
+          </div>
+        </div>
 
-        <div style={{ marginTop:12, fontSize:12, color:"#475569" }}>{plan.startISO} {(plan as any).endISO ? `→ ${(plan as any).endISO}` : ""}</div>
+        <div
+          style={{
+            display: "flex",
+            gap: 8,
+            flexWrap: "wrap",
+            fontSize: 13,
+            color: "#475569",
+          }}
+        >
+          <span>
+            {plan.startISO}
+            {plan.endISO ? ` → ${plan.endISO}` : ""}
+          </span>
+        </div>
 
-        <ul style={{ listStyle:"none", margin:0, padding:0, display:"grid", gap:12, marginTop:12 }}>
-          {byDay.map(({ d, items }) => (
-            <li key={d} style={{ border:"1px solid #e5e7eb", borderRadius:12, padding:12, background:"#fff" }}>
-              <div style={{ fontWeight:800, marginBottom:6 }}>{d}</div>
-              <DayTimeline dateISO={d} reservations={items} />
-            </li>
+        <div style={{ display: "grid", gap: 12 }}>
+          <div style={{ fontWeight: 800, fontSize: 16, color: "#0f172a" }}>
+            Trip calendar
+          </div>
+          {calendarMonths.map((month) => (
+            <div key={month.key} style={{ display: "grid", gap: 6 }}>
+              <div style={{ fontWeight: 700, color: "#0f172a", fontSize: 14 }}>
+                {month.label}
+              </div>
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "repeat(7, minmax(0, 1fr))",
+                  textAlign: "center",
+                  fontSize: 11,
+                  color: "#94a3b8",
+                  gap: 4,
+                }}
+              >
+                {WEEK_LABELS.map((w) => (
+                  <div key={`${month.key}-${w}`}>{w}</div>
+                ))}
+              </div>
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "repeat(7, minmax(0, 1fr))",
+                  gap: 6,
+                }}
+              >
+                {month.cells.map((cell, idx) => {
+                  if (!cell.iso) {
+                    return <div key={`${month.key}-empty-${idx}`} />;
+                  }
+                  const isSelected = cell.iso === selectedDay;
+                  const isDisabled = !cell.inTrip;
+                  return (
+                    <button
+                      key={cell.iso}
+                      onClick={() => {
+                        if (!cell.iso || isDisabled) return;
+                        setSelectedDay(cell.iso);
+                      }}
+                      disabled={isDisabled}
+                      style={{
+                        border: isSelected
+                          ? "1px solid #0ea5a8"
+                          : "1px solid transparent",
+                        background: isSelected
+                          ? "linear-gradient(120deg,#06b6d4,#0ea5a8)"
+                          : "#f8fafc",
+                        color: isSelected
+                          ? "#fff"
+                          : isDisabled
+                          ? "#cbd5e1"
+                          : "#0f172a",
+                        borderRadius: 12,
+                        padding: "6px 0",
+                        minHeight: 58,
+                        display: "flex",
+                        flexDirection: "column",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        gap: 6,
+                        cursor: isDisabled ? "default" : "pointer",
+                        boxShadow: isSelected
+                          ? "0 12px 28px rgba(14,165,233,0.25)"
+                          : "none",
+                        transition: "transform 0.15s ease",
+                      }}
+                    >
+                      <span style={{ fontWeight: 700 }}>{cell.label}</span>
+                      <div style={{ display: "flex", gap: 4 }}>
+                        {cell.reservationCount > 0 && (
+                          <span
+                            title={`${cell.reservationCount} reservation${
+                              cell.reservationCount === 1 ? "" : "s"
+                            }`}
+                            style={{
+                              width: 8,
+                              height: 8,
+                              borderRadius: "50%",
+                              background: "#0284c7",
+                              display: "inline-block",
+                            }}
+                          />
+                        )}
+                        {cell.activityCount > 0 && (
+                          <span
+                            title={`${cell.activityCount} planned item${
+                              cell.activityCount === 1 ? "" : "s"
+                            }`}
+                            style={{
+                              width: 8,
+                              height: 8,
+                              borderRadius: "50%",
+                              background: "#22c55e",
+                              display: "inline-block",
+                            }}
+                          />
+                        )}
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
           ))}
-        </ul>
+        </div>
+
+        {selectedDay && (
+          <div
+            style={{
+              border: "1px solid #e2e8f0",
+              borderRadius: 18,
+              background: "#f8fafc",
+              padding: 0,
+            }}
+          >
+            <div
+              style={{
+                padding: "16px 20px",
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 12,
+                alignItems: "center",
+                borderBottom: "1px solid #e2e8f0",
+                background: "#fff",
+                borderTopLeftRadius: 18,
+                borderTopRightRadius: 18,
+              }}
+            >
+              <div style={{ fontWeight: 800, fontSize: 16, color: "#0f172a" }}>
+                {selectedDayLabel || selectedDay}
+              </div>
+              <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                <span
+                  style={{
+                    background: "#e0f2fe",
+                    color: "#0369a1",
+                    padding: "4px 10px",
+                    borderRadius: 999,
+                    fontSize: 12,
+                    fontWeight: 700,
+                  }}
+                >
+                  {selectedReservations} reservation
+                  {selectedReservations === 1 ? "" : "s"}
+                </span>
+                <span
+                  style={{
+                    background: "#dcfce7",
+                    color: "#15803d",
+                    padding: "4px 10px",
+                    borderRadius: 999,
+                    fontSize: 12,
+                    fontWeight: 700,
+                  }}
+                >
+                  {selectedActivities} planned item
+                  {selectedActivities === 1 ? "" : "s"}
+                </span>
+              </div>
+            </div>
+            <DayPlanner
+              key={selectedDay}
+              dateISO={selectedDay}
+              activities={activitiesByDay[selectedDay] || []}
+              reservations={reservations}
+              onAdd={(payload) => onAddActivity(selectedDay, payload)}
+              onUpdate={(activityId, updates) =>
+                onUpdateActivity(selectedDay, activityId, updates)
+              }
+              onRemove={(activityId) =>
+                onRemoveActivity(selectedDay, activityId)
+              }
+            />
+          </div>
+        )}
       </div>
     </div>
   );
 }
 
-function DayTimeline({ dateISO, reservations }: { dateISO: string; reservations: Reservation[] }): JSX.Element {
-  const [events, setEvents] = useState<{ id: string; start: string; end?: string; title: string; type?: string }[]>([]);
-  const blocks = useMemo(() => {
-    const toBlocks = (arr: { start: string; end?: string; title: string }[], color: string) => {
-      return arr.map((a, i) => {
-        const sh = Number(a.start.slice(11,13) || "0"), sm = Number(a.start.slice(14,16) || "0");
-        const eh = Number((a.end||a.start).slice(11,13) || "0"), em = Number((a.end||a.start).slice(14,16) || "0");
-        const startMin = sh*60+sm, endMin = Math.max(eh*60+em, startMin+30);
-        return { top: (startMin/60)*44, height: ((endMin-startMin)/60)*44, title: a.title, key: a.title+"-"+i, color };
-      });
-    };
-    const res = toBlocks(reservations.map(r => ({ start: r.startISO, end: r.endISO, title: (r.type.toUpperCase()) + (r.title?": "+r.title:"") })), "#e0f2fe");
-    const user = toBlocks(events.map(e => ({ start: e.start, end: e.end, title: (e.type?`[${e.type}] `:"")+e.title })), "#dcfce7");
-    return [...res, ...user];
-  }, [reservations, events]);
+type DayPlannerProps = {
+  dateISO: string;
+  activities: TripActivity[];
+  reservations: Reservation[];
+  onAdd: (input: {
+    title: string;
+    start: string;
+    end: string;
+    category?: string;
+    notes?: string;
+  }) => void;
+  onUpdate: (
+    activityId: string,
+    updates: {
+      title?: string;
+      start?: string;
+      end?: string;
+      category?: string;
+      notes?: string;
+    }
+  ) => void;
+  onRemove: (activityId: string) => void;
+};
 
-  function addEvent() {
-    const title = prompt("Item (e.g., Dinner at …)");
-    if (!title) return;
-    const type = prompt("Type (Meal / Flight / Sightseeing) optional") || undefined;
-    const s = prompt("Start (HH:MM 24h)") || "12:00";
-    const e = prompt("End (HH:MM 24h, optional)") || undefined;
-    const mk = (hhmm: string) => dateISO + "T" + (hhmm.length===5?hhmm:hhmm.padStart(5,"0")) + ":00";
-    setEvents(prev => [...prev, { id: String(Date.now())+Math.random(), title, type, start: mk(s), end: e ? mk(e) : undefined }]);
+const CATEGORY_OPTIONS = [
+  { value: "experience", label: "Experience", icon: "🗺️" },
+  { value: "meal", label: "Meal", icon: "🍽️" },
+  { value: "travel", label: "Travel", icon: "🚆" },
+  { value: "free", label: "Downtime", icon: "🧘" },
+];
+
+function categoryStyle(category?: string) {
+  const key = category?.toLowerCase();
+  switch (key) {
+    case "meal":
+      return {
+        bg: "#fef3c7",
+        border: "#fcd34d",
+        text: "#92400e",
+        badgeBg: "rgba(217, 119, 6, 0.12)",
+        badgeText: "#92400e",
+        label: "Meal",
+        icon: "🍽️",
+      };
+    case "travel":
+      return {
+        bg: "#fee2e2",
+        border: "#fca5a5",
+        text: "#991b1b",
+        badgeBg: "rgba(185, 28, 28, 0.12)",
+        badgeText: "#991b1b",
+        label: "Travel",
+        icon: "🚆",
+      };
+    case "other":
+      return {
+        bg: "#f1f5f9",
+        border: "#cbd5e1",
+        text: "#0f172a",
+        badgeBg: "rgba(15, 23, 42, 0.08)",
+        badgeText: "#0f172a",
+        label: "Custom",
+        icon: "✨",
+      };
+    case "free":
+      return {
+        bg: "#e2e8f0",
+        border: "#cbd5e1",
+        text: "#1e293b",
+        badgeBg: "rgba(30, 41, 59, 0.08)",
+        badgeText: "#475569",
+        label: "Downtime",
+        icon: "🧘",
+      };
+    case "experience":
+    default:
+      return {
+        bg: "#dcfce7",
+        border: "#86efac",
+        text: "#166534",
+        badgeBg: "rgba(22, 101, 52, 0.12)",
+        badgeText: "#166534",
+        label: "Experience",
+        icon: "🗺️",
+      };
   }
+}
+
+function formatReservationType(type: ReservationType) {
+  switch (type) {
+    case "flight":
+      return "Flight";
+    case "hotel":
+      return "Hotel";
+    case "train":
+      return "Train";
+    case "event":
+    default:
+      return "Event";
+  }
+}
+
+function DayPlanner({
+  dateISO,
+  activities,
+  reservations,
+  onAdd,
+  onUpdate,
+  onRemove,
+}: DayPlannerProps): JSX.Element {
+  const dayDate = useMemo(() => new Date(`${dateISO}T00:00:00`), [dateISO]);
+  const headerLabel = dayDate.toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  });
+
+  const sortedActivities = useMemo(
+    () => activities.slice().sort((a, b) => a.startISO.localeCompare(b.startISO)),
+    [activities]
+  );
+
+  const dayReservations = useMemo(
+    () =>
+      reservations.filter(
+        (res) => clipRangeToDay(dateISO, res.startISO, res.endISO) !== null
+      ),
+    [reservations, dateISO]
+  );
+
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draft, setDraft] = useState({
+    title: "",
+    start: "09:00",
+    end: "11:00",
+    category: "experience",
+    notes: "",
+  });
+
+  const resetDraft = () => {
+    setDraft({ title: "", start: "09:00", end: "11:00", category: "experience", notes: "" });
+    setEditingId(null);
+  };
+
+  const beginEdit = (activity: TripActivity) => {
+    setShowForm(true);
+    setEditingId(activity.id);
+    setDraft({
+      title: activity.title,
+      start: activity.startISO.slice(11, 16),
+      end: activity.endISO.slice(11, 16),
+      category: activity.category || "experience",
+      notes: activity.notes || "",
+    });
+  };
+
+  const cancelForm = () => {
+    resetDraft();
+    setShowForm(false);
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const title = draft.title.trim();
+    if (!title) return;
+    const start = normalizeHHMM(draft.start);
+    const endNormalized = normalizeHHMM(draft.end, start);
+    const ensured = ensureEndAfterStart(start, endNormalized);
+    const payload = {
+      title,
+      start,
+      end: ensured.end,
+      category: draft.category,
+      notes: draft.notes.trim() || undefined,
+    };
+    if (editingId) {
+      onUpdate(editingId, payload);
+    } else {
+      onAdd(payload);
+    }
+    resetDraft();
+    setShowForm(false);
+  };
+
+  const pxPerHour = 36;
+  const pxPerMinute = pxPerHour / 60;
+  const timelineHeight = pxPerHour * 24;
+
+  const timelineBlocks = useMemo(() => {
+    const blocks: {
+      id: string;
+      top: number;
+      height: number;
+      title: string;
+      subtitle?: string;
+      bg: string;
+      border: string;
+      text: string;
+      badge?: string;
+      badgeBg?: string;
+      badgeText?: string;
+      icon?: string;
+    }[] = [];
+
+    const formatRange = (startISO: string, endISO?: string) => {
+      const start = startISO.slice(11, 16);
+      const end = (endISO || startISO).slice(11, 16);
+      return `${start} – ${end}`;
+    };
+
+    dayReservations.forEach((res) => {
+      const clipped = clipRangeToDay(dateISO, res.startISO, res.endISO);
+      if (!clipped) return;
+      const { startMin, endMin } = clipped;
+      const title = res.title || formatReservationType(res.type);
+      const subtitleParts = [
+        formatRange(res.startISO, res.endISO),
+        formatReservationType(res.type),
+      ];
+      if (res.location?.city) subtitleParts.push(res.location.city);
+      const subtitle = subtitleParts.join(" · ");
+      blocks.push({
+        id: `res-${res.id}`,
+        top: startMin * pxPerMinute,
+        height: Math.max(34, (endMin - startMin) * pxPerMinute),
+        title,
+        subtitle,
+        bg: "#dbeafe",
+        border: "#93c5fd",
+        text: "#1d4ed8",
+        badge: "Reservation",
+        badgeBg: "rgba(59,130,246,0.14)",
+        badgeText: "#1d4ed8",
+        icon: "📌",
+      });
+    });
+
+    sortedActivities.forEach((activity) => {
+      const clipped = clipRangeToDay(
+        dateISO,
+        activity.startISO,
+        activity.endISO
+      );
+      if (!clipped) return;
+      const { startMin, endMin } = clipped;
+      const style = categoryStyle(activity.category);
+      const subtitleParts = [
+        `${activity.startISO.slice(11, 16)} – ${activity.endISO.slice(11, 16)}`,
+      ];
+      if (activity.notes) subtitleParts.push(activity.notes);
+      blocks.push({
+        id: `act-${activity.id}`,
+        top: startMin * pxPerMinute,
+        height: Math.max(40, (endMin - startMin) * pxPerMinute),
+        title: activity.title,
+        subtitle: subtitleParts.join(" · "),
+        bg: style.bg,
+        border: style.border,
+        text: style.text,
+        badge: style.label,
+        badgeBg: style.badgeBg,
+        badgeText: style.badgeText,
+        icon: style.icon,
+      });
+    });
+
+    return blocks.sort((a, b) => a.top - b.top);
+  }, [sortedActivities, dayReservations, dateISO, pxPerMinute]);
+
+  const disableSubmit = !draft.title.trim();
 
   return (
-    <div>
-      <div style={{ display:"grid", gridTemplateColumns:"62px 1fr", gap:10 }}>
-        <div style={{ display:"grid", gridTemplateRows:"repeat(24, 44px)" }}>
-          {Array.from({ length: 24 }).map((_, h) => (
-            <div key={h} style={{ fontSize: 12, color: "#64748b" }}>{String(h).padStart(2,"0")}:00</div>
+    <div style={{ padding: 16, display: "grid", gap: 16 }}>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 12, alignItems: "center" }}>
+        <div style={{ fontSize: 18, fontWeight: 800, color: "#0f172a" }}>{headerLabel}</div>
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <span
+            style={{
+              background: "#e0f2fe",
+              color: "#0369a1",
+              padding: "4px 10px",
+              borderRadius: 999,
+              fontSize: 12,
+              fontWeight: 600,
+            }}
+          >
+            {dayReservations.length} reservation{dayReservations.length === 1 ? "" : "s"}
+          </span>
+          <span
+            style={{
+              background: "#dcfce7",
+              color: "#15803d",
+              padding: "4px 10px",
+              borderRadius: 999,
+              fontSize: 12,
+              fontWeight: 600,
+            }}
+          >
+            {sortedActivities.length} planned item{sortedActivities.length === 1 ? "" : "s"}
+          </span>
+        </div>
+      </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: "70px 1fr", gap: 12 }}>
+        <div
+          style={{
+            display: "grid",
+            gridTemplateRows: `repeat(24, ${pxPerHour}px)`,
+            justifyItems: "flex-end",
+            fontSize: 11,
+            color: "#94a3b8",
+            paddingTop: 2,
+            rowGap: 0,
+          }}
+        >
+          {Array.from({ length: 24 }).map((_, hour) => (
+            <div key={hour}>{String(hour).padStart(2, "0")}:00</div>
           ))}
         </div>
-        <div style={{ position: "relative", border: "1px solid #e5e7eb", borderRadius: 12, height: 24 * 44, background: "#f8fafc" }}>
-          {blocks.map(b => (
-            <div key={b.key} style={{ position: "absolute", left: 8, right: 8, top: b.top, height: b.height, background: b.color, borderRadius: 8, padding: "6px 8px", fontSize: 12, border: "1px solid #e2e8f0", overflow: "hidden", whiteSpace: "nowrap", textOverflow: "ellipsis" }}>
-              {b.title}
+        <div
+          style={{
+            position: "relative",
+            border: "1px solid #e2e8f0",
+            borderRadius: 16,
+            height: timelineHeight,
+            background: "#f8fafc",
+            overflow: "hidden",
+          }}
+        >
+          {Array.from({ length: 25 }).map((_, idx) => (
+            <div
+              key={`hour-${idx}`}
+              style={{
+                position: "absolute",
+                left: 0,
+                right: 0,
+                top: idx * pxPerHour,
+                borderTop: idx === 0 ? "none" : "1px solid rgba(148,163,184,0.28)",
+              }}
+            />
+          ))}
+          {Array.from({ length: 24 }).map((_, idx) => (
+            <div
+              key={`half-${idx}`}
+              style={{
+                position: "absolute",
+                left: 8,
+                right: 8,
+                top: idx * pxPerHour + pxPerHour / 2,
+                borderTop: "1px dashed rgba(148,163,184,0.2)",
+              }}
+            />
+          ))}
+          {timelineBlocks.map((block) => (
+            <div
+              key={block.id}
+              style={{
+                position: "absolute",
+                left: 10,
+                right: 10,
+                top: block.top,
+                height: block.height,
+                background: block.bg,
+                border: `1px solid ${block.border}`,
+                color: block.text,
+                borderRadius: 14,
+                padding: "10px 12px",
+                boxShadow: "0 14px 30px rgba(15, 23, 42, 0.08)",
+                display: "flex",
+                flexDirection: "column",
+                gap: 6,
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  fontWeight: 700,
+                  fontSize: 13,
+                }}
+              >
+                <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                  {block.icon && <span>{block.icon}</span>}
+                  {block.title}
+                </span>
+                {block.badge && (
+                  <span
+                    style={{
+                      background: block.badgeBg || "rgba(15,23,42,0.06)",
+                      color: block.badgeText || "#0f172a",
+                      padding: "2px 8px",
+                      borderRadius: 999,
+                      fontSize: 10,
+                      fontWeight: 700,
+                    }}
+                  >
+                    {block.badge}
+                  </span>
+                )}
+              </div>
+              {block.subtitle && (
+                <div style={{ fontSize: 11, color: "rgba(15,23,42,0.7)" }}>
+                  {block.subtitle}
+                </div>
+              )}
             </div>
           ))}
         </div>
       </div>
-      <div style={{ display:"flex", justifyContent:"flex-end", marginTop:8 }}>
-        <button onClick={addEvent} style={{ border:"1px solid #e5e7eb", borderRadius:8, padding:"6px 10px" }}>Add item</button>
+
+      <div style={{ display: "grid", gap: 12 }}>
+        <div style={{ fontWeight: 700, fontSize: 14, color: "#0f172a" }}>Planned items</div>
+        {sortedActivities.length === 0 ? (
+          <div style={{ fontSize: 13, color: "#64748b" }}>
+            No custom plans yet. Add ideas below to build your perfect day.
+          </div>
+        ) : (
+          <div style={{ display: "grid", gap: 10 }}>
+            {sortedActivities.map((activity) => {
+              const style = categoryStyle(activity.category);
+              return (
+                <div
+                  key={activity.id}
+                  style={{
+                    border: `1px solid ${style.border}`,
+                    background: "#fff",
+                    borderRadius: 14,
+                    padding: "12px 14px",
+                    display: "grid",
+                    gap: 6,
+                    boxShadow: "0 10px 30px rgba(15,23,42,0.05)",
+                  }}
+                >
+                  <div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
+                    <div style={{ fontWeight: 700, color: "#0f172a", display: "flex", gap: 8, alignItems: "center" }}>
+                      <span>{style.icon}</span>
+                      <span>{activity.title}</span>
+                    </div>
+                    <div style={{ display: "flex", gap: 8 }}>
+                      <button
+                        onClick={() => beginEdit(activity)}
+                        style={{
+                          border: "1px solid #cbd5e1",
+                          background: "#f8fafc",
+                          borderRadius: 999,
+                          padding: "4px 10px",
+                          fontSize: 11,
+                          cursor: "pointer",
+                        }}
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => onRemove(activity.id)}
+                        style={{
+                          border: "1px solid #fecaca",
+                          background: "#fee2e2",
+                          color: "#b91c1c",
+                          borderRadius: 999,
+                          padding: "4px 10px",
+                          fontSize: 11,
+                          cursor: "pointer",
+                        }}
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  </div>
+                  <div style={{ fontSize: 12, color: "#1e293b" }}>
+                    {activity.startISO.slice(11, 16)} – {activity.endISO.slice(11, 16)}
+                    {style.label ? ` · ${style.label}` : ""}
+                  </div>
+                  {activity.notes && (
+                    <div style={{ fontSize: 12, color: "#475569" }}>{activity.notes}</div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      <div style={{ display: "grid", gap: 12 }}>
+        <div style={{ fontWeight: 700, fontSize: 14, color: "#0f172a" }}>Reservations</div>
+        {dayReservations.length === 0 ? (
+          <div style={{ fontSize: 13, color: "#64748b" }}>
+            No reservations block this day yet.
+          </div>
+        ) : (
+          <div style={{ display: "grid", gap: 10 }}>
+            {dayReservations.map((res) => (
+              <div
+                key={res.id}
+                style={{
+                  border: "1px solid #bfdbfe",
+                  background: "#eff6ff",
+                  borderRadius: 12,
+                  padding: "10px 12px",
+                  display: "grid",
+                  gap: 4,
+                  fontSize: 12,
+                }}
+              >
+                <div style={{ fontWeight: 700, color: "#1d4ed8" }}>
+                  {res.title || formatReservationType(res.type)}
+                </div>
+                <div style={{ color: "#1e3a8a" }}>
+                  {res.startISO.slice(11, 16)} – {(res.endISO || res.startISO).slice(11, 16)}
+                  {res.location?.city ? ` · ${res.location.city}` : ""}
+                </div>
+                {res.notes && (
+                  <div style={{ color: "#334155" }}>{res.notes}</div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div
+        style={{
+          border: "1px dashed #cbd5e1",
+          borderRadius: 16,
+          padding: "16px",
+          background: showForm ? "#ffffff" : "#f8fafc",
+          display: "grid",
+          gap: 12,
+        }}
+      >
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div style={{ fontWeight: 700, fontSize: 14, color: "#0f172a" }}>
+            {editingId ? "Update plan item" : "Add to this day"}
+          </div>
+          {!showForm && (
+            <button
+              onClick={() => setShowForm(true)}
+              style={{
+                border: "1px solid #38bdf8",
+                background: "linear-gradient(135deg,#06b6d4,#0ea5a8)",
+                color: "#fff",
+                borderRadius: 999,
+                padding: "6px 14px",
+                fontSize: 12,
+                fontWeight: 700,
+                cursor: "pointer",
+              }}
+            >
+              Plan something
+            </button>
+          )}
+        </div>
+        {showForm && (
+          <form onSubmit={handleSubmit} style={{ display: "grid", gap: 10 }}>
+            <div style={{ display: "grid", gap: 6 }}>
+              <label style={{ fontSize: 12, color: "#475569", fontWeight: 600 }}>Title</label>
+              <input
+                value={draft.title}
+                onChange={(e) => setDraft((prev) => ({ ...prev, title: e.target.value }))}
+                placeholder="e.g. TeamLab Planets"
+                style={{
+                  padding: "10px 12px",
+                  borderRadius: 10,
+                  border: "1px solid #cbd5e1",
+                  fontSize: 13,
+                }}
+              />
+            </div>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit,minmax(120px,1fr))", gap: 12 }}>
+              <div style={{ display: "grid", gap: 6 }}>
+                <label style={{ fontSize: 12, color: "#475569", fontWeight: 600 }}>Start</label>
+                <input
+                  value={draft.start}
+                  onChange={(e) => setDraft((prev) => ({ ...prev, start: e.target.value }))}
+                  type="time"
+                  style={{ padding: "10px 12px", borderRadius: 10, border: "1px solid #cbd5e1" }}
+                />
+              </div>
+              <div style={{ display: "grid", gap: 6 }}>
+                <label style={{ fontSize: 12, color: "#475569", fontWeight: 600 }}>End</label>
+                <input
+                  value={draft.end}
+                  onChange={(e) => setDraft((prev) => ({ ...prev, end: e.target.value }))}
+                  type="time"
+                  style={{ padding: "10px 12px", borderRadius: 10, border: "1px solid #cbd5e1" }}
+                />
+              </div>
+              <div style={{ display: "grid", gap: 6 }}>
+                <label style={{ fontSize: 12, color: "#475569", fontWeight: 600 }}>Category</label>
+                <select
+                  value={draft.category}
+                  onChange={(e) => setDraft((prev) => ({ ...prev, category: e.target.value }))}
+                  style={{ padding: "10px 12px", borderRadius: 10, border: "1px solid #cbd5e1", fontSize: 13 }}
+                >
+                  {CATEGORY_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.icon} {opt.label}
+                    </option>
+                  ))}
+                  <option value="other">✨ Something else</option>
+                </select>
+              </div>
+            </div>
+            <div style={{ display: "grid", gap: 6 }}>
+              <label style={{ fontSize: 12, color: "#475569", fontWeight: 600 }}>Notes</label>
+              <textarea
+                value={draft.notes}
+                onChange={(e) => setDraft((prev) => ({ ...prev, notes: e.target.value }))}
+                rows={3}
+                placeholder="Add details, confirmation numbers, meeting points…"
+                style={{
+                  padding: "10px 12px",
+                  borderRadius: 10,
+                  border: "1px solid #cbd5e1",
+                  fontSize: 13,
+                  resize: "vertical",
+                }}
+              />
+            </div>
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+              <button
+                type="button"
+                onClick={cancelForm}
+                style={{
+                  border: "1px solid #cbd5e1",
+                  background: "#f8fafc",
+                  borderRadius: 999,
+                  padding: "6px 14px",
+                  fontSize: 12,
+                  cursor: "pointer",
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={disableSubmit}
+                style={{
+                  border: "none",
+                  background: disableSubmit
+                    ? "#cbd5e1"
+                    : "linear-gradient(135deg,#06b6d4,#0ea5a8)",
+                  color: disableSubmit ? "#fff" : "#fff",
+                  borderRadius: 999,
+                  padding: "6px 18px",
+                  fontSize: 12,
+                  fontWeight: 700,
+                  cursor: disableSubmit ? "not-allowed" : "pointer",
+                  opacity: disableSubmit ? 0.7 : 1,
+                }}
+              >
+                {editingId ? "Save changes" : "Add to plan"}
+              </button>
+            </div>
+          </form>
+        )}
       </div>
     </div>
   );

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,2 @@
+declare module "topojson-client";
+declare module "d3-geo";


### PR DESCRIPTION
## Summary
- allow naming trips during creation and persist the titles alongside country metadata
- redesign planned trip cards with default scenic covers and click-to-open behaviour while surfacing countdowns
- overhaul the trip detail view with a month-style calendar selector, per-day summaries, and smoother focus handling on search inputs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9a75443688332bdbf64de6a46aaca